### PR TITLE
Fix mozaic library loading

### DIFF
--- a/lib/turbolinks-animate/railtie.rb
+++ b/lib/turbolinks-animate/railtie.rb
@@ -1,4 +1,5 @@
 require 'rails/railtie'
+require 'mozaic'
 
 module TurbolinksAnimate
     class Railtie < Rails::Railtie


### PR DESCRIPTION
Right now it will raise an error:
```
➜  traintool git:(turbolinks-animation) ✗ rails c
/Users/kirill/Code/turbolinks-animate/lib/turbolinks-animate/railtie.rb:8:in `block in <class:Railtie>': uninitialized constant TurbolinksAnimate::Railtie::Mozaic (NameError)
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/railties-5.1.6/lib/rails/initializable.rb:30:in `instance_exec'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/railties-5.1.6/lib/rails/initializable.rb:30:in `run'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/railties-5.1.6/lib/rails/initializable.rb:59:in `block in run_initializers'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `call'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/railties-5.1.6/lib/rails/initializable.rb:58:in `run_initializers'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/railties-5.1.6/lib/rails/application.rb:353:in `initialize!'
	from /Users/kirill/Code/traintool/config/environment.rb:5:in `<top (required)>'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application.rb:102:in `preload'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application.rb:153:in `serve'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
	from /Users/kirill/.rvm/gems/ruby-2.3.1/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/kirill/.rvm/rubies/ruby-2.3.1/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```